### PR TITLE
fix(client/NavBarHome)fix_logout_redirect_to_landing

### DIFF
--- a/client/src/Components/NavBar/NavHome.jsx
+++ b/client/src/Components/NavBar/NavHome.jsx
@@ -18,9 +18,7 @@ const NavHome = () => {
   };
 
 useEffect(() => {
-    if (user !== null) {
-      navigate("/home");
-    } else {
+    if (user === null) {
       navigate("/");
     }
 }, [user])


### PR DESCRIPTION
Modifique el useEFfect del componente NavBarHome para que al desloguear redirija a /landing y eliminar bug del click parpadeando.