### PR TITLE
fix(client/component/navHome)Welcome_loginWithEmailAndPassword

### DIFF
--- a/client/src/Components/NavBar/NavHome.jsx
+++ b/client/src/Components/NavBar/NavHome.jsx
@@ -1,13 +1,19 @@
 import { Link } from "react-router-dom";
 import logo from "../../assets/logo2.jpeg";
 import ScrollHome from "../Scroll/ScrollHome";
-import { UserAuth } from "../../context/AuthContext";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { auth } from "../../firebase/firebase.config";
+import { UserAuth } from "../../context/AuthContext";
+
 
 const NavHome = () => {
+
   const navigate = useNavigate();
-  const { user, signOutWithGoogle } = UserAuth();
+  const { signOutWithGoogle } = UserAuth();
+  const [user, setUser] = useState(null); // Estado local para el usuario autenticado
+
+
   const logOutWithGoogle = async () => {
     try {
       await signOutWithGoogle();
@@ -16,11 +22,21 @@ const NavHome = () => {
     }
   };
 
-  useEffect(() => {
-    if (user === null) {
-      navigate("/");
-    }
-  }, [user]);
+    // Observador de cambios de autenticación de Firebase
+    useEffect(() => {
+      const unsubscribe = auth.onAuthStateChanged((authUser) => {
+        if (authUser) {
+          // Usuario autenticado, establecer el estado local
+          setUser(authUser);
+        } else {
+          // Usuario no autenticado, redirigir a la página de inicio de sesión u otra acción
+          navigate("/");
+        }
+      });
+  
+      // Limpia el observador cuando el componente se desmonta
+      return () => unsubscribe();
+    }, [navigate]);
 
   return (
     <nav className="bg-black-100">
@@ -57,7 +73,7 @@ const NavHome = () => {
                         <button onClick={logOutWithGoogle}>LOG OUT</button>
                       </a>
                     </Link>
-                    <h3>Welcome, {user.displayName}</h3>
+                    <h3>Welcome, {user ? user.displayName || user.email : ''}</h3>
                   </div>
                 </div>
               </div>

--- a/client/src/Views/Login/Login.jsx
+++ b/client/src/Views/Login/Login.jsx
@@ -31,7 +31,7 @@ const Login = () => {
             await signInWithEmailAndPassword(auth, email, password); // Usa getAuth(auth)
             navigate('/home');
         } catch (error) {
-            console.error("Error al iniciar sesión con correo y contraseña:", error.message);
+            alert("Error al iniciar sesión con correo y contraseña: verificar datos", error.message);
         }
     };
 


### PR DESCRIPTION
arreglado el mensaje en la navHome para que muestre el welcome personificado tanto para autenticacion con google como email y password.

![image](https://github.com/N-Cano/PF-HealthPlus/assets/124411705/80ded88d-b637-45d6-a79d-7799f5000c87)
