### PR TITLE
Fix(api/controllers):searchbyname(user&doctors)

### DIFF
--- a/api/src/controllers/doctorsControllers.js
+++ b/api/src/controllers/doctorsControllers.js
@@ -58,35 +58,31 @@ const createDoctor = async (data) => {
 };
 
 // --- Bring doctor by name ---
-
 const bringDoctorByName = async (name) => {
     try {
         const doctorRef = await db.collection('doctors').get();
-        const doctors = [];
+        let foundDoctor = null;
+
         doctorRef.forEach((doc) => {
-            doctors.push({
+            const doctorData = {
                 id: doc.id,
                 ...doc.data()
-            })
-        });
-        const lowerName = name.toLowerCase()
-        const matchDoctors = [];
-        doctors.forEach((doctor) => {
-            if (doctor.name
-                .toLowerCase()
-                .includes(lowerName)) {
-                matchDoctors.push(doctor)
-            }
-        })
-        return {
-            doctorsMatched: matchDoctors.length,
-            matchDoctors
-        }
+            };
 
+            if (doctorData.name.toLowerCase().includes(name.toLowerCase())) {
+                foundDoctor = doctorData;
+                return; 
+            }
+        });
+
+        if (foundDoctor) {
+            return foundDoctor;
+        } else throw new Error(`No doctor matched with name: ${name}`) 
     } catch (error) {
-        throw new Error(error)
+        throw new Error(error);
     }
 };
+
 
 // --- Delete a doctor ---
 

--- a/api/src/controllers/usersControllers.js
+++ b/api/src/controllers/usersControllers.js
@@ -61,33 +61,29 @@ const bringUsers = async () => {
 const bringUsersByName = async (name) => {
   try {
     const userRef = await db.collection('users').get();
-    const users = [];
+    let foundUser = null;
+
     userRef.forEach((user) => {
-      users.push({
+      const userData = {
         id: user.id,
         ...user.data()
-      })
-    });
-    const lowerName = name.toLowerCase()
-    const matchUsers = [];
-    users.forEach((user) => {
-      if (user.name
-        .toLowerCase()
-        .includes(lowerName)
-        || user.lastName
-          .toLowerCase()
-          .includes(lowerName)) {
-        matchUsers.push(user)
+      };
+
+      if (userData.name.toLowerCase().includes(name.toLowerCase()) || userData.lastName.toLowerCase().includes(name.toLowerCase())) {
+        foundUser = userData;
+        return;
       }
-    })
-    return {
-      usersMatched: matchUsers.length,
-      matchUsers
-    }
+    });
+
+    if (foundUser) {
+      return foundUser;
+    } else throw new Error(`No user matched with name: ${name}`)
+
   } catch (error) {
-    throw new Error(error)
+    throw new Error(error);
   }
 };
+
 
 // --- Bring an user by id from data base ---
 


### PR DESCRIPTION
Fix bringDoctorByName y bringUserByName para que la búsqueda sea inexacta y devuelva un solo objeto.
La búsqueda se detiene cuando encuentra el primer elemento coincidente 
por lo que si hay usuarios o doctores con nombres iguales encuentra al primero únicamente. 
Para el segundo se debe escribir nombre + apellido y lo encuentra igualmente.